### PR TITLE
run: fixup mkdir syntax

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 trap signal_handler INT
 signal_handler() {
@@ -12,7 +12,7 @@ do
 	for l in 200
 	do
 		dir="./data/article/$r/$l"
-		mkdir -p "$dir/{species,sizes,distances,position}"
+		mkdir -p "$dir/"{species,sizes,distances,position}
 
 		echo "real;usr;sys" > "$dir/performance_$l.txt"
 


### PR DESCRIPTION
This commit fixes the quote position in the `mkdir` command, so that it
creates `n` new folders as opposed to a single folder.

Also specify bash as shell interpreter as only it supports this syntax
feature.

Signed-off-by: Isabella Basso <isabbasso@riseup.net>
